### PR TITLE
fix: Fix the Azure redirect with invalidAuthenticationIfo

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -93,12 +93,19 @@ function download(url, file, dest) {
  */
 function downloadOtherWorkflowArtifact(octokit, { owner, repo, artifactId, downloadPath }) {
     return __awaiter(this, void 0, void 0, function* () {
-        const artifact = yield octokit.actions.downloadArtifact({
+        const response = yield octokit.request('GET /repos/{owner}/{repo}/actions/artifacts/{artifact_id}/{archive_format}', {
             owner,
             repo,
             artifact_id: artifactId,
             archive_format: 'zip',
+            request: {
+                redirect: 'manual',
+            },
         });
+        const downloadUrl = response.headers.location;
+        if (!downloadUrl) {
+            throw new Error(`Failed to get artifact download URL for artifact ${artifactId}: missing Location header in response`);
+        }
         // Make sure output path exists
         try {
             yield io.mkdirP(downloadPath);
@@ -107,7 +114,7 @@ function downloadOtherWorkflowArtifact(octokit, { owner, repo, artifactId, downl
             // ignore errors
         }
         const downloadFile = path_1.default.resolve(downloadPath, FILENAME);
-        return yield download(artifact.url, downloadFile, downloadPath);
+        return yield download(downloadUrl, downloadFile, downloadPath);
     });
 }
 exports.downloadOtherWorkflowArtifact = downloadOtherWorkflowArtifact;
@@ -1392,7 +1399,7 @@ function downloadSnapshots({ artifactName, rootDirectory, }) {
             throw new Error('Unable to find artifact: ' + artifactName);
         }
         const resp = yield artifactClient.downloadArtifact(artifactResp.artifact.id, {
-            path: `${rootDirectory}/${artifactName}/`
+            path: `${rootDirectory}/${artifactName}/`,
         });
         if (resp.downloadPath == null) {
             throw new Error('Unable to find artifact: ' + artifactName);
@@ -51942,6 +51949,88 @@ exports.Octokit = Octokit;
 
 /***/ }),
 
+/***/ 99910:
+/***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
+
+"use strict";
+
+
+Object.defineProperty(exports, "__esModule", ({ value: true }));
+
+function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
+
+var deprecation = __nccwpck_require__(58932);
+var once = _interopDefault(__nccwpck_require__(1223));
+
+const logOnceCode = once(deprecation => console.warn(deprecation));
+const logOnceHeaders = once(deprecation => console.warn(deprecation));
+/**
+ * Error with extra properties to help with debugging
+ */
+
+class RequestError extends Error {
+  constructor(message, statusCode, options) {
+    super(message); // Maintains proper stack trace (only available on V8)
+
+    /* istanbul ignore next */
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, this.constructor);
+    }
+
+    this.name = "HttpError";
+    this.status = statusCode;
+    let headers;
+
+    if ("headers" in options && typeof options.headers !== "undefined") {
+      headers = options.headers;
+    }
+
+    if ("response" in options) {
+      this.response = options.response;
+      headers = options.response.headers;
+    } // redact request credentials without mutating original request options
+
+
+    const requestCopy = Object.assign({}, options.request);
+
+    if (options.request.headers.authorization) {
+      requestCopy.headers = Object.assign({}, options.request.headers, {
+        authorization: options.request.headers.authorization.replace(/ .*$/, " [REDACTED]")
+      });
+    }
+
+    requestCopy.url = requestCopy.url // client_id & client_secret can be passed as URL query parameters to increase rate limit
+    // see https://developer.github.com/v3/#increasing-the-unauthenticated-rate-limit-for-oauth-applications
+    .replace(/\bclient_secret=\w+/g, "client_secret=[REDACTED]") // OAuth tokens can be passed as URL query parameters, although it is not recommended
+    // see https://developer.github.com/v3/#oauth2-token-sent-in-a-header
+    .replace(/\baccess_token=\w+/g, "access_token=[REDACTED]");
+    this.request = requestCopy; // deprecations
+
+    Object.defineProperty(this, "code", {
+      get() {
+        logOnceCode(new deprecation.Deprecation("[@octokit/request-error] `error.code` is deprecated, use `error.status`."));
+        return statusCode;
+      }
+
+    });
+    Object.defineProperty(this, "headers", {
+      get() {
+        logOnceHeaders(new deprecation.Deprecation("[@octokit/request-error] `error.headers` is deprecated, use `error.response.headers`."));
+        return headers || {};
+      }
+
+    });
+  }
+
+}
+
+exports.RequestError = RequestError;
+//# sourceMappingURL=index.js.map
+
+
+/***/ }),
+
 /***/ 6039:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
@@ -51956,7 +52045,7 @@ var endpoint = __nccwpck_require__(59440);
 var universalUserAgent = __nccwpck_require__(45030);
 var isPlainObject = __nccwpck_require__(3708);
 var nodeFetch = _interopDefault(__nccwpck_require__(13801));
-var requestError = __nccwpck_require__(10537);
+var requestError = __nccwpck_require__(99910);
 
 const VERSION = "5.6.3";
 
@@ -266668,7 +266757,7 @@ module.exports = JSON.parse('["ac","com.ac","edu.ac","gov.ac","net.ac","mil.ac",
 /***/ ((module) => {
 
 "use strict";
-module.exports = JSON.parse('{"name":"action-visual-snapshot","version":"0.0.1","private":true,"description":"GitHub Action to diff images","main":"lib/main.js","scripts":{"build":"yarn tsc --build tsconfig.build.json","build-template":"yarn ts-node src/template/build","dev:gallery":"nodemon --watch src/template/index.ejs --watch src/template/dev.ts --exec \\"ts-node\\" ./src/template/dev.ts","format":"yarn prettier --write **/*.ts","format-check":"yarn prettier --check **/*.ts","lint":"eslint src/**/*.ts","dist":"yarn build-template && yarn build && yarn ncc build -C -s","test":"yarn jest","all":"yarn build && yarn format && yarn lint && yarn test && yarn dist"},"repository":{"type":"git","url":"git+https://github.com/getsentry/action-visual-snapshot.git"},"keywords":["actions","node","visual-snapshot","snapshot","testing","visual-regression"],"author":"Sentry","license":"MIT","husky":{"hooks":{"pre-commit":"lint-staged"}},"lint-staged":{"*.{html,ejs}":["yarn prettier --parser html --write"],"*.{js,jsx,ts,tsx}":["yarn eslint --fix","yarn prettier --write"]},"resolutions":{"node-forge":"^0.10.0"},"dependencies":{"@actions/artifact":"^2.2.1","@actions/core":"^1.2.6","@actions/exec":"^1.0.4","@actions/github":"^4.0.0","@actions/glob":"^0.1.0","@actions/io":"^1.0.2","@google-cloud/storage":"^5.4.0","@sentry/integrations":"^5.27.4","@sentry/node":"^5.27.4","@sentry/tracing":"^5.27.4","@types/async-retry":"^1.4.2","@types/bent":"^7.3.0","@types/ejs":"^3.0.4","@types/pixelmatch":"^5.2.2","@types/pngjs":"^3.4.2","@types/uuid":"^8.3.0","async-retry":"^1.3.1","bent":"^7.3.11","ejs":"^3.1.5","pixelmatch":"^5.2.1","pngjs":"^5.0.0","uuid":"^8.3.0"},"devDependencies":{"@types/jest":"^26.0.14","@types/node":"^14.0.14","@typescript-eslint/eslint-plugin":"^4.4.0","@typescript-eslint/parser":"^4.4.0","@vercel/ncc":"^0.33.3","eslint":"^7.10.0","eslint-config-sentry":"^1.44.0","eslint-plugin-jest":"^24.1.0","eslint-plugin-prettier":"^3.1.4","husky":"^4.3.0","jest":"^26.5.2","jest-circus":"^26.5.2","js-yaml":"^3.13.1","lint-staged":"^10.4.0","nodemon":"^2.0.4","prettier":"^2.1.2","ts-jest":"^26.4.1","ts-node":"^9.0.0","typescript":"^4.0.3"}}');
+module.exports = JSON.parse('{"name":"action-visual-snapshot","version":"0.0.1","private":true,"description":"GitHub Action to diff images","main":"lib/main.js","scripts":{"build":"yarn tsc --build tsconfig.build.json","build-template":"yarn ts-node src/template/build","dev:gallery":"nodemon --watch src/template/index.ejs --watch src/template/dev.ts --exec \\"ts-node\\" ./src/template/dev.ts","format":"yarn prettier --write **/*.ts","format-check":"yarn prettier --check **/*.ts","lint":"eslint src/**/*.ts","dist":"yarn build-template && yarn build && yarn ncc build -C -s","test":"yarn jest","all":"yarn build && yarn format && yarn lint && yarn test && yarn dist"},"repository":{"type":"git","url":"git+https://github.com/getsentry/action-visual-snapshot.git"},"keywords":["actions","node","visual-snapshot","snapshot","testing","visual-regression"],"author":"Sentry","license":"MIT","husky":{"hooks":{"pre-commit":"lint-staged"}},"lint-staged":{"*.{html,ejs}":["yarn prettier --parser html --write"],"*.{js,jsx,ts,tsx}":["yarn eslint --fix","yarn prettier --write"]},"resolutions":{"node-forge":"^0.10.0"},"dependencies":{"@actions/artifact":"^2.2.1","@actions/core":"^1.2.6","@actions/exec":"^1.0.4","@actions/github":"^4.0.0","@actions/glob":"^0.1.0","@actions/io":"^1.0.2","@google-cloud/storage":"^5.4.0","@sentry/integrations":"^5.27.4","@sentry/node":"^5.27.4","@sentry/tracing":"^5.27.4","@types/async-retry":"^1.4.2","@types/bent":"^7.3.0","@types/ejs":"^3.0.4","@types/pixelmatch":"^5.2.2","@types/pngjs":"^3.4.2","@types/uuid":"^8.3.0","async-retry":"^1.3.1","bent":"^7.3.11","ejs":"^3.1.5","pixelmatch":"^5.2.1","pngjs":"^5.0.0","uuid":"^8.3.0"},"devDependencies":{"@types/jest":"^26.0.14","@types/node":"^14.0.14","@typescript-eslint/eslint-plugin":"^4.4.0","@typescript-eslint/parser":"^4.4.0","@vercel/ncc":"^0.33.3","eslint":"^7.10.0","eslint-config-sentry":"^1.44.0","eslint-plugin-jest":"^27.9.0","eslint-plugin-prettier":"^3.1.4","husky":"^4.3.0","jest":"^26.5.2","jest-circus":"^26.5.2","js-yaml":"^3.13.1","lint-staged":"^10.4.0","nodemon":"^2.0.4","prettier":"^2.1.2","ts-jest":"^26.4.1","ts-node":"^9.0.0","typescript":"^4.0.3"}}');
 
 /***/ })
 

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@vercel/ncc": "^0.33.3",
     "eslint": "^7.10.0",
     "eslint-config-sentry": "^1.44.0",
-    "eslint-plugin-jest": "^24.1.0",
+    "eslint-plugin-jest": "^27.9.0",
     "eslint-plugin-prettier": "^3.1.4",
     "husky": "^4.3.0",
     "jest": "^26.5.2",

--- a/src/api/downloadOtherWorkflowArtifact.ts
+++ b/src/api/downloadOtherWorkflowArtifact.ts
@@ -69,12 +69,26 @@ export async function downloadOtherWorkflowArtifact(
   octokit: ReturnType<typeof github.getOctokit>,
   {owner, repo, artifactId, downloadPath}: DownloadArtifactParams
 ) {
-  const artifact = await octokit.actions.downloadArtifact({
-    owner,
-    repo,
-    artifact_id: artifactId,
-    archive_format: 'zip',
-  });
+  const response = await octokit.request(
+    'GET /repos/{owner}/{repo}/actions/artifacts/{artifact_id}/{archive_format}',
+    {
+      owner,
+      repo,
+      artifact_id: artifactId,
+      archive_format: 'zip',
+      request: {
+        redirect: 'manual',
+      },
+    }
+  );
+
+  const downloadUrl = (response.headers as Record<string, string>).location;
+
+  if (!downloadUrl) {
+    throw new Error(
+      `Failed to get artifact download URL for artifact ${artifactId}: missing Location header in response`
+    );
+  }
 
   // Make sure output path exists
   try {
@@ -85,5 +99,5 @@ export async function downloadOtherWorkflowArtifact(
 
   const downloadFile = path.resolve(downloadPath, FILENAME);
 
-  return await download(artifact.url, downloadFile, downloadPath);
+  return await download(downloadUrl, downloadFile, downloadPath);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -663,6 +663,13 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@eslint-community/eslint-utils@^4.2.0":
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz#4e90af67bc51ddee6cdef5284edf572ec376b595"
+  integrity sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==
+  dependencies:
+    eslint-visitor-keys "^3.4.3"
+
 "@eslint/eslintrc@^0.1.3":
   version "0.1.3"
   resolved "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.1.3.tgz"
@@ -1435,6 +1442,11 @@
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz"
   integrity sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==
 
+"@types/json-schema@^7.0.9":
+  version "7.0.15"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
+  integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
+
 "@types/node@*", "@types/node@^14.0.14":
   version "14.0.14"
   resolved "https://registry.npmjs.org/@types/node/-/node-14.0.14.tgz"
@@ -1479,6 +1491,11 @@
   resolved "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz"
   integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
 
+"@types/semver@^7.3.12":
+  version "7.7.1"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.7.1.tgz#3ce3af1a5524ef327d2da9e4fd8b6d95c8d70528"
+  integrity sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==
+
 "@types/stack-utils@^2.0.0":
   version "2.0.0"
   resolved "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.0.tgz"
@@ -1514,7 +1531,7 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@4.4.0", "@typescript-eslint/experimental-utils@^4.0.1":
+"@typescript-eslint/experimental-utils@4.4.0":
   version "4.4.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.4.0.tgz"
   integrity sha512-01+OtK/oWeSJTjQcyzDztfLF1YjvKpLFo+JZmurK/qjSRcyObpIecJ4rckDoRCSh5Etw+jKfdSzVEHevh9gJ1w==
@@ -1544,10 +1561,23 @@
     "@typescript-eslint/types" "4.4.0"
     "@typescript-eslint/visitor-keys" "4.4.0"
 
+"@typescript-eslint/scope-manager@5.62.0":
+  version "5.62.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz#d9457ccc6a0b8d6b37d0eb252a23022478c5460c"
+  integrity sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==
+  dependencies:
+    "@typescript-eslint/types" "5.62.0"
+    "@typescript-eslint/visitor-keys" "5.62.0"
+
 "@typescript-eslint/types@4.4.0":
   version "4.4.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.4.0.tgz"
   integrity sha512-nU0VUpzanFw3jjX+50OTQy6MehVvf8pkqFcURPAE06xFNFenMj1GPEI6IESvp7UOHAnq+n/brMirZdR+7rCrlA==
+
+"@typescript-eslint/types@5.62.0":
+  version "5.62.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.62.0.tgz#258607e60effa309f067608931c3df6fed41fd2f"
+  integrity sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==
 
 "@typescript-eslint/typescript-estree@4.4.0":
   version "4.4.0"
@@ -1563,6 +1593,33 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
+"@typescript-eslint/typescript-estree@5.62.0":
+  version "5.62.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz#7d17794b77fabcac615d6a48fb143330d962eb9b"
+  integrity sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==
+  dependencies:
+    "@typescript-eslint/types" "5.62.0"
+    "@typescript-eslint/visitor-keys" "5.62.0"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    semver "^7.3.7"
+    tsutils "^3.21.0"
+
+"@typescript-eslint/utils@^5.10.0":
+  version "5.62.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.62.0.tgz#141e809c71636e4a75daa39faed2fb5f4b10df86"
+  integrity sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.2.0"
+    "@types/json-schema" "^7.0.9"
+    "@types/semver" "^7.3.12"
+    "@typescript-eslint/scope-manager" "5.62.0"
+    "@typescript-eslint/types" "5.62.0"
+    "@typescript-eslint/typescript-estree" "5.62.0"
+    eslint-scope "^5.1.1"
+    semver "^7.3.7"
+
 "@typescript-eslint/visitor-keys@4.4.0":
   version "4.4.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.4.0.tgz"
@@ -1570,6 +1627,14 @@
   dependencies:
     "@typescript-eslint/types" "4.4.0"
     eslint-visitor-keys "^2.0.0"
+
+"@typescript-eslint/visitor-keys@5.62.0":
+  version "5.62.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz#2174011917ce582875954ffe2f6912d5931e353e"
+  integrity sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==
+  dependencies:
+    "@typescript-eslint/types" "5.62.0"
+    eslint-visitor-keys "^3.3.0"
 
 "@vercel/ncc@^0.33.3":
   version "0.33.3"
@@ -2061,6 +2126,13 @@ braces@^3.0.1, braces@~3.0.2:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
+
+braces@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
+  integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
+  dependencies:
+    fill-range "^7.1.1"
 
 browser-process-hrtime@^1.0.0:
   version "1.0.0"
@@ -2781,12 +2853,12 @@ eslint-config-sentry@^1.44.0:
   resolved "https://registry.npmjs.org/eslint-config-sentry/-/eslint-config-sentry-1.44.0.tgz"
   integrity sha512-h606V52km91Cvo80NoWVTpGt53GWlRL5fAvLL9yeVNgIebjiI6yOAA9Cftgm/dAj2R1aauLZ5ka0lwKZtfJt7w==
 
-eslint-plugin-jest@^24.1.0:
-  version "24.1.0"
-  resolved "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.1.0.tgz"
-  integrity sha512-827YJ+E8B9PvXu/0eiVSNFfxxndbKv+qE/3GSMhdorCaeaOehtqHGX2YDW9B85TEOre9n/zscledkFW/KbnyGg==
+eslint-plugin-jest@^27.9.0:
+  version "27.9.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-27.9.0.tgz#7c98a33605e1d8b8442ace092b60e9919730000b"
+  integrity sha512-QIT7FH7fNmd9n4se7FFKHbsLKGQiw885Ds6Y/sxKgCZ6natwCsXdgPOADnYVxN2QrRweF0FZWbJ6S7Rsn7llug==
   dependencies:
-    "@typescript-eslint/experimental-utils" "^4.0.1"
+    "@typescript-eslint/utils" "^5.10.0"
 
 eslint-plugin-prettier@^3.1.4:
   version "3.1.4"
@@ -2827,6 +2899,11 @@ eslint-visitor-keys@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz"
   integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
+
+eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.3:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz#0cd72fe8550e3c2eae156a96a4dddcd1c8ac5800"
+  integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
 
 eslint@^7.10.0:
   version "7.10.0"
@@ -3070,6 +3147,17 @@ fast-glob@^3.1.1:
     micromatch "^4.0.2"
     picomatch "^2.2.1"
 
+fast-glob@^3.2.9:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.3.tgz#d06d585ce8dba90a16b0505c543c3ccfb3aeb818"
+  integrity sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.8"
+
 fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz"
@@ -3141,6 +3229,13 @@ fill-range@^7.0.1:
   version "7.0.1"
   resolved "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz"
   integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
+  dependencies:
+    to-regex-range "^5.0.1"
+
+fill-range@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.1.1.tgz#44265d3cac07e3ea7dc247516380643754a05292"
+  integrity sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==
   dependencies:
     to-regex-range "^5.0.1"
 
@@ -3317,6 +3412,13 @@ glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@~5.1.0:
   dependencies:
     is-glob "^4.0.1"
 
+glob-parent@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
+  integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
+  dependencies:
+    is-glob "^4.0.1"
+
 glob@^10.0.0:
   version "10.4.5"
   resolved "https://registry.yarnpkg.com/glob/-/glob-10.4.5.tgz#f4d9f0b90ffdbab09c9d77f5f29b4262517b0956"
@@ -3382,6 +3484,18 @@ globby@^11.0.1:
     fast-glob "^3.1.1"
     ignore "^5.1.4"
     merge2 "^1.3.0"
+    slash "^3.0.0"
+
+globby@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
+  integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
+  dependencies:
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.2.9"
+    ignore "^5.2.0"
+    merge2 "^1.4.1"
     slash "^3.0.0"
 
 google-auth-library@^7.0.0, google-auth-library@^7.0.2:
@@ -3625,6 +3739,11 @@ ignore@^5.1.4:
   resolved "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz"
   integrity sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
 
+ignore@^5.2.0:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"
+  integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
+
 immediate@~3.0.5:
   version "3.0.6"
   resolved "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz"
@@ -3795,6 +3914,13 @@ is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
   version "4.0.1"
   resolved "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz"
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
+  dependencies:
+    is-extglob "^2.1.1"
+
+is-glob@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.3.tgz#64f61e42cbbb2eec2071a9dac0b28ba1e65d5084"
+  integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
   dependencies:
     is-extglob "^2.1.1"
 
@@ -4779,7 +4905,7 @@ merge-stream@^2.0.0:
   resolved "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz"
   integrity sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
 
-merge2@^1.3.0:
+merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
@@ -4810,6 +4936,14 @@ micromatch@^4.0.2:
   dependencies:
     braces "^3.0.1"
     picomatch "^2.0.5"
+
+micromatch@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
+  integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==
+  dependencies:
+    braces "^3.0.3"
+    picomatch "^2.3.1"
 
 mime-db@1.44.0, "mime-db@>= 1.43.0 < 2":
   version "1.44.0"
@@ -5283,6 +5417,11 @@ picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1:
   version "2.2.2"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
+
+picomatch@^2.3.1:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.2.tgz#5a942915e26b372dc0f0e6753149a16e6b1c5601"
+  integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
 
 pirates@^4.0.1:
   version "4.0.1"
@@ -5809,6 +5948,11 @@ semver@^6.0.0, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.3.7:
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.4.tgz#c73eceebae0616934be8dff28a7fd70757c8e696"
+  integrity sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==
 
 set-blocking@^2.0.0:
   version "2.0.0"
@@ -6474,6 +6618,13 @@ tsutils@^3.17.1:
   version "3.17.1"
   resolved "https://registry.npmjs.org/tsutils/-/tsutils-3.17.1.tgz"
   integrity sha512-kzeQ5B8H3w60nFY2g8cJIuH7JDpsALXySGtwGJ0p2LSjLgay3NdIpqq5SoOBe46bKDW2iq25irHCr8wjomUS2g==
+  dependencies:
+    tslib "^1.8.1"
+
+tsutils@^3.21.0:
+  version "3.21.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
+  integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
   dependencies:
     tslib "^1.8.1"
 


### PR DESCRIPTION
Problem:
Downloading base snapshots from a previous workflow run was failing with:

Server failed to authenticate the request. The access token was missing or malformed.
status: 401
www-authenticate: *** resource_id=https://storage.azure.com```
https://github.com/linz/topographic-system/actions/runs/27646904191/job/81762496131#logs
Octokit auto-follows GitHub's 302 redirect to Azure, forwarding the GitHub bearer token which Azure rejects with 401.

Change
use redirect: 'manual' to prevents Octokit from following the redirect.
stops Octokit from following the redirect so the Azure SAS URL can be extracted from the Location header and fetched directly without sending the GitHub token to Azure.
Validation
https://github.com/linz/topographic-system/pull/205